### PR TITLE
[SPARTA-598][WEB]: Use /download/{id} endpoint instead of /find/{id} when downloading a policy

### DIFF
--- a/web/src/scripts/controllers/policy-list.js
+++ b/web/src/scripts/controllers/policy-list.js
@@ -21,10 +21,10 @@
     .controller('PolicyListCtrl', PolicyListCtrl);
 
   PolicyListCtrl.$inject = ['WizardStatusService', 'PolicyFactory', 'PolicyModelFactory', 'ModalService', '$state',
-    '$translate', '$interval', '$filter', '$scope', '$q'];
+    '$translate', '$interval', '$filter', '$scope', '$q', '$window'];
 
   function PolicyListCtrl(WizardStatusService, PolicyFactory, PolicyModelFactory, ModalService, $state,
-                          $translate, $interval, $filter, $scope, $q) {
+                          $translate, $interval, $filter, $scope, $q, $window) {
     /*jshint validthis: true*/
     var vm = this;
 
@@ -37,6 +37,7 @@
     vm.editPolicy = editPolicy;
     vm.deleteErrorMessage = deleteErrorMessage;
     vm.deleteSuccessMessage = deleteSuccessMessage;
+    vm.downloadPolicy = downloadPolicy;
 
     vm.policiesData = {};
     vm.policiesData.list = undefined;
@@ -203,6 +204,16 @@
         $interval.cancel(checkPoliciesStatus);
         vm.successMessage.text = '_ERROR_._' + error.data.i18nCode + '_';
       });
+    }
+
+    function downloadPolicy(policyId) {
+      PolicyFactory.downloadPolicy(policyId).then(function (policyFile) {
+        var blob = new Blob([JSON.stringify(policyFile)], {type: "text/plain;charset=utf-8"});
+        var url = ( $window.URL || $window.webkitURL).createObjectURL(blob);
+        var a = $("<a/>").attr({href: url, download: policyFile.name + ".json"});
+        a[0].click();
+        a.remove();
+      })
     }
 
     /*Stop $interval when changing the view*/

--- a/web/src/scripts/factories/policy-factory.js
+++ b/web/src/scripts/factories/policy-factory.js
@@ -36,11 +36,11 @@
       createPolicy: function (newPolicyData) {
         return ApiPolicyService.createPolicy().create(newPolicyData).$promise;
       },
-      deletePolicy: function (policyid) {
-        return ApiPolicyService.deletePolicy().delete({'id': policyid}).$promise;
+      deletePolicy: function (policyId) {
+        return ApiPolicyService.deletePolicy().delete({'id': policyId}).$promise;
       },
-      runPolicy: function (policyid) {
-        return ApiPolicyService.runPolicy().get({'id': policyid}).$promise;
+      runPolicy: function (policyId) {
+        return ApiPolicyService.runPolicy().get({'id': policyId}).$promise;
       },
       stopPolicy: function (policy) {
         return ApiPolicyService.stopPolicy().update(policy).$promise;
@@ -50,6 +50,9 @@
       },
       getPoliciesStatus: function () {
         return ApiPolicyService.getPoliciesStatus().get().$promise;
+      },
+      downloadPolicy: function (policyId) {
+        return ApiPolicyService.downloadPolicy().get({'id': policyId}).$promise;
       },
       getFakePolicy: function () {
         return ApiPolicyService.getFakePolicy().get().$promise;

--- a/web/src/scripts/services/api/api-policy-service.js
+++ b/web/src/scripts/services/api/api-policy-service.js
@@ -35,6 +35,7 @@
     vm.savePolicy = savePolicy;
     vm.stopPolicy = stopPolicy;
     vm.getPoliciesStatus = getPoliciesStatus;
+    vm.downloadPolicy = downloadPolicy;
 
     /////////////////////////////////
 
@@ -87,16 +88,20 @@
     function runPolicy() {
       return $resource('/policy/run/:id', {id: '@id'},
         {
-            'get': {method:'GET',
-            timeout: apiConfigSettings.timeout}
+          'get': {
+            method: 'GET',
+            timeout: apiConfigSettings.timeout
+          }
         });
     }
 
     function stopPolicy() {
       return $resource('/policyContext', {},
         {
-          'update': {method: 'PUT',
-            timeout: apiConfigSettings.timeout}
+          'update': {
+            method: 'PUT',
+            timeout: apiConfigSettings.timeout
+          }
         });
     }
 
@@ -127,6 +132,15 @@
             method: 'GET',
             timeout: apiConfigSettings.timeout
           }
+        });
+    }
+
+
+    function downloadPolicy() {
+      return $resource('/policy/download/:id', {id: '@id'},
+        {
+          'get': {method: 'GET'},
+          timeout: apiConfigSettings.timeout
         });
     }
   }

--- a/web/src/stratio-ui/template/components/ui.stratio.menuElement.html
+++ b/web/src/stratio-ui/template/components/ui.stratio.menuElement.html
@@ -1,33 +1,21 @@
 <a
-	ui-sref-active="active"
-	class="element"
-	ng-if="href && !sref"
-	href="{{href}}"
-	data-qa="{{qaref}}"
-	ng-attr-target= "{{target || null}}"
-	ng-attr-download="{{downloadFileName}}">
+  ui-sref-active="active"
+  class="element"
+  ng-if="href || sref"
+  href="{{sref ? '' : href}}"
+  ng-attr-ui-sref="{{sref || null}}"
+  data-qa="{{qaref}}">
 
-	<em ng-if="classIcon" class="ico {{classIcon}}"></em>
-	<span ng-transclude></span>
-</a>
-
-<a
-	ui-sref-active="active"
-	class="element"
-	ng-if="sref"
-	href
-	ui-sref="{{sref}}"
-	data-qa="{{qaref}}"
-	ng-attr-download="{{downloadFileName}}">
-
-	<em ng-if="classIcon" class="ico {{classIcon}}"></em>
-	<span ng-transclude></span>
+  <em ng-if="classIcon" class="ico {{classIcon}}"></em>
+  <span ng-transclude></span>
 </a>
 
 <span
-	class="element"
-	ng-if="!(href || sref)">
+  ui-sref-active="active"
+  class="element"
+  ng-if="!(href || sref)">
 
-	<em ng-if="classIcon" class="ico {{classIcon}}"></em>
-	<span ng-transclude></span>
-</span>
+		<em ng-if="classIcon" class="ico {{classIcon}}"></em>
+		<span ng-transclude></span>
+	</span>
+</div>

--- a/web/src/views/policies.html
+++ b/web/src/views/policies.html
@@ -48,8 +48,8 @@
                                  data-qa="policy-context-menu-{{policyData.policy.id}}-edit">
                   {{"_OUTPUT_ACTIONS_MENU_EDIT_" | translate}}
                 </st-menu-element>
-                <st-menu-element class-icon="icon-download" data-href="/policy/find/{{policyData.policy.id}}"
-                                 data-download-file-name="{{policyData.policy.name}}.json"
+                <st-menu-element class-icon="icon-download"
+                                 data-ng-click="policies.downloadPolicy(policyData.policy.id)"
                                  data-qa="policy-context-menu-{{policyData.policy.id}}-download">
                   {{"_OUTPUT_ACTIONS_MENU_DOWNLOAD_" | translate}}
                 </st-menu-element>

--- a/web/test/API/policy-service.js
+++ b/web/test/API/policy-service.js
@@ -59,7 +59,7 @@ describe('API.policy-service', function () {
 
   	srv.createPolicy().create().$promise.then(function(result){
   		expect(JSON.stringify(result)).toEqual(JSON.stringify(fakePolicyById));
-  	})
+  	});
 
   	rootScope.$digest();
     httpBackend.flush();
@@ -85,7 +85,7 @@ describe('API.policy-service', function () {
 
 		srv.runPolicy().get(policyIdJSON).$promise.then(function(result){
 			expect(JSON.stringify(result)).toEqual(JSON.stringify(policyRunningJSON));
-		})
+		});
 
 		rootScope.$digest();
 		httpBackend.flush();
@@ -124,5 +124,17 @@ describe('API.policy-service', function () {
 		rootScope.$digest();
 		httpBackend.flush();
 	});
+
+  it("Should download a policy by its Id", function () {
+  var policyId = '2581f20a-av83-4315-be45-192bc5sEdFff';
+    httpBackend.when('GET', '/policy/download/'+ policyId).respond(fakePolicyById);
+
+    srv.downloadPolicy().get({id: policyId}).$promise.then(function(result){
+      expect(JSON.stringify(result)).toEqual(JSON.stringify(fakePolicyById));
+    });
+
+    rootScope.$digest();
+    httpBackend.flush();
+  });
 
  });

--- a/web/test/controllers/policies-controller.js
+++ b/web/test/controllers/policies-controller.js
@@ -32,7 +32,7 @@ describe('policies.wizard.controller.policies-controller', function () {
     $httpBackend.when('GET', 'languages/en-US.json')
       .respond({});
     fakeCreationStatus = {"currentStep": 0};
-    policyFactoryMock = jasmine.createSpyObj('PolicyFactory', ['createPolicy', 'getAllPolicies', 'getPoliciesStatus', 'runPolicy', 'stopPolicy']);
+    policyFactoryMock = jasmine.createSpyObj('PolicyFactory', ['createPolicy', 'getAllPolicies', 'getPoliciesStatus', 'runPolicy', 'stopPolicy', 'downloadPolicy']);
     policyFactoryMock.getAllPolicies.and.callFake(function () {
       var defer = $q.defer();
       defer.resolve(fakePolicyList);
@@ -154,5 +154,20 @@ describe('policies.wizard.controller.policies-controller', function () {
       });
     })
   });
+
+
+  describe("should be able to download a policy", function(){
+    it("policy factory is called to download the policy passing its id", function(){
+      var fakePolicyId = "fake policy id";
+      policyFactoryMock.downloadPolicy.and.callFake(resolvedPromise);
+      ctrl.downloadPolicy(fakePolicyId);
+
+      expect(policyFactoryMock.downloadPolicy).toHaveBeenCalledWith(fakePolicyId);
+      });
+
+    it ("a hidden element is created in order to force the file downloading", function(){
+
+    })
+  })
 
 });

--- a/web/test/policies/wizard/factory/policy-factory.js
+++ b/web/test/policies/wizard/factory/policy-factory.js
@@ -6,7 +6,7 @@ describe('policies.wizard.factory.policy-factory', function () {
 
   beforeEach(module(function ($provide) {
     ApiPolicyService = jasmine.createSpyObj('ApiPolicyService', ['getPolicyByFragmentId', 'getPolicyById',
-      'getAllPolicies', 'createPolicy', 'deletePolicy', 'runPolicy', 'stopPolicy', 'savePolicy', 'getPoliciesStatus', 'getFakePolicy']);
+      'getAllPolicies', 'createPolicy', 'deletePolicy', 'runPolicy', 'stopPolicy', 'savePolicy', 'getPoliciesStatus', 'getFakePolicy', 'downloadPolicy']);
 
     // inject mocks
     $provide.value('ApiPolicyService', ApiPolicyService);
@@ -144,6 +144,18 @@ describe('policies.wizard.factory.policy-factory', function () {
 
       expect(promiseMock).toHaveBeenCalledWith();
     });
+
+    it("download a policy by its id", function () {
+      var fakePolicyId = "fake policy id";
+      ApiPolicyService.downloadPolicy.and.returnValue(
+        {
+          "get": promiseMock
+        });
+
+      factory.downloadPolicy(fakePolicyId);
+
+      expect(promiseMock).toHaveBeenCalledWith({"id": fakePolicyId});
+    });
   });
 
 
@@ -163,7 +175,6 @@ describe('policies.wizard.factory.policy-factory', function () {
           }
         });
     });
-
 
     afterEach(function () {
       scope.$apply();
@@ -187,7 +198,4 @@ describe('policies.wizard.factory.policy-factory', function () {
       });
     });
   })
-
-
-})
-;
+});


### PR DESCRIPTION
**Given** policy list page
**When** I click on menu of a policy and I select 'download' option
**Then** The policy file with the name of the policy and its content is downloaded to my computer
